### PR TITLE
Fix multiple sites configuration issue

### DIFF
--- a/custom_components/kumo_cloud/config_flow.py
+++ b/custom_components/kumo_cloud/config_flow.py
@@ -134,8 +134,9 @@ class KumoCloudConfigFlow(ConfigFlow, domain=DOMAIN):
             site for site in self.data["sites"] if site["id"] == self.data[CONF_SITE_ID]
         )
 
-        # Use username as unique ID
-        await self.async_set_unique_id(self.data[CONF_USERNAME])
+        # Use username and site ID as unique ID to allow multiple sites per account
+        unique_id = f"{self.data[CONF_USERNAME]}_{self.data[CONF_SITE_ID]}"
+        await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(


### PR DESCRIPTION
Allow users to configure multiple Kumo Cloud sites by changing the unique ID from username-only to username+site_id combination. This resolves issue #8 where users with multiple mini split systems could only configure one site.

🤖 Generated with [Claude Code](https://claude.ai/code)